### PR TITLE
Add fastcgi_read_timeout 120

### DIFF
--- a/root/etc/templates/default
+++ b/root/etc/templates/default
@@ -20,6 +20,7 @@ server {
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;
 		# With php5-cgi alone:
 		fastcgi_pass 127.0.0.1:${FASTCGIPORT};
+		fastcgi_read_timeout 120;
 		# With php5-fpm:
 		#fastcgi_pass unix:/var/run/php5-fpm.sock;
 		fastcgi_index index.php;


### PR DESCRIPTION
This fixes a lot of upstream timeout messages from GET api.php