### PR TITLE
Fix auto-update

### DIFF
--- a/root/etc/cont-init.d/40-install
+++ b/root/etc/cont-init.d/40-install
@@ -35,5 +35,6 @@ git pull
 # permissions
 chown -R abc:abc /config/www
 chmod -R 777 /config
+git config core.fileMode false
 	
 


### PR DESCRIPTION
Prevent permission changes from breaking automatic updates.

Currently when an update occurs, this message is received:

```
Updating Phlex.
From https://github.com/d8ahazard/Phlex
   f2a4722..9aec9ff  master     -> origin/master
Updating f2a4722..9aec9ff
error: Your local changes to the following files would be overwritten by merge:
	api.php
	index.php
	service-worker.js
Please commit your changes or stash them before you merge.
Aborting
[cont-init.d] 40-install: exited 0.
```

executing `git diff` shows that this is because of permissions.

```
$ git diff
diff --git a/.gitattributes b/.gitattributes
old mode 100644
new mode 100755
diff --git a/.gitignore b/.gitignore
old mode 100644
new mode 100755
diff --git a/ISSUE_TEMPLATE.md b/ISSUE_TEMPLATE.md
old mode 100644
new mode 100755
diff --git a/PHPTail.php b/PHPTail.php
old mode 100644
new mode 100755
diff --git a/api.php b/api.php
old mode 100644
new mode 100755
diff --git a/body.php b/body.php
old mode 100644
new mode 100755
diff --git a/browserconfig.xml b/browserconfig.xml
old mode 100644
new mode 100755
diff --git a/cast/CCBaseSender.php b/cast/CCBaseSender.php
old mode 100644
new mode 100755
```

The standard way to prevent this from occurring, unless you want to permanently elevate the permissions, is to [configure git to ignore permissions changes](https://stackoverflow.com/questions/1580596/how-do-i-make-git-ignore-file-mode-chmod-changes).

With that change, the auto-update works as intended:

```
Updating Phlex.
Updating f2a4722..9aec9ff
Fast-forward
 api.php           |  10 ++---
 index.php         |   4 +-
 service-worker.js | 120 +++++++++++++++++++++++++++---------------------------
 3 files changed, 67 insertions(+), 67 deletions(-)
[cont-init.d] 40-install: exited 0.
```


  